### PR TITLE
Skip goodbye message if skipGoodbye option is specified.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -94,6 +94,10 @@ module.exports = Generator.extend({
   },
 
   end: function () {
+    if (this.options.skipGoodbye) {
+      return;
+    }
+
     var finalWords;
     if (this.options.installDeps) {
       finalWords = 'All done!\n' +


### PR DESCRIPTION
skipGoodbye is an ad hoc convention respected by generator-gadget so that "master" generators can use these and keep the final word around such things as next steps.