### PR TITLE
Purge files from previous generator run

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -49,6 +49,7 @@ module.exports = Generator.extend({
 
   default: function () {
     var cmd = [
+      'rm -f master.tar.gz pattern-lab-starter-master patternlab',
       'curl -OL https://github.com/phase2/pattern-lab-starter/archive/master.tar.gz',
       'tar -xzf master.tar.gz',
       'mv pattern-lab-starter-master patternlab',

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -48,8 +48,10 @@ module.exports = Generator.extend({
   },
 
   default: function () {
+    var dest = options.themePath ? path.resolve(process.cwd(), options.themePath) : './';
+
     var cmd = [
-      'rm -f master.tar.gz pattern-lab-starter-master patternlab',
+      'rm -Rf master.tar.gz pattern-lab-starter-master patternlab' + ' ' + dest + '/patternlab' ,
       'curl -OL https://github.com/phase2/pattern-lab-starter/archive/master.tar.gz',
       'tar -xzf master.tar.gz',
       'mv pattern-lab-starter-master patternlab',
@@ -74,7 +76,7 @@ module.exports = Generator.extend({
           encoding: 'utf8'
         });
       } catch(error) {
-        console.error('Could not "mkdir -p" the themePath. That might be bad, it might not...');
+        console.error('Could not "mkdir -p" the themePath.');
       }
 
       try {


### PR DESCRIPTION
If you re-run the generator in the same directory, or anything goes wrong with clean-up of intermediary files, their is a fatal error and nothing can happen.

This makes a preemptive effort to remove the files which could get in the way, using -f so it does not throw an error if a file does not exist or fails to remove.

Hoping this fixes #21 sufficiently.