### PR TITLE
Overhaul on upstream retrieval.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
 
 This is a [Yeoman](http://yeoman.io) generator for [Particle](https://github.com/phase2/pattern-lab-starter), a modern design-system driven Drupal theme.
 
+## Install
+
 To install generator-pattern-lab-starter from npm, run:
 
 ```bash
 npm install -g generator-pattern-lab-starter
 ```
+
+## Usage
 
 *Note that this template will generate files in the current directory, so be sure to change to a new directory first if you don't want to overwrite existing files.*
 
@@ -21,6 +25,10 @@ Extras can be installed with:
 ```bash
 yo pattern-lab-starter:extras
 ```
+
+### Options
+
+* **release**: Run with `--release=<branch-tag-or-hash>` to override the default use of master branch.
 
 ## Docker-based Development
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var Generator = require('yeoman-generator');
-var chalk = require('chalk');
-var exec = require('child_process').execSync;
-var fs = require('fs-extra');
-var path = require('path');
-var yosay = require('yosay');
-var _ = require('lodash');
-var myPrompts = require('./prompts.js');
+const Generator = require('yeoman-generator');
+const chalk = require('chalk');
+const exec = require('child_process').execSync;
+const fs = require('fs-extra');
+const path = require('path');
+const yosay = require('yosay');
+const _ = require('lodash');
+const myPrompts = require('./prompts.js');
 
 var options = {};
 
@@ -45,15 +45,15 @@ module.exports = Generator.extend({
 
   default: function () {
     const release = options['release'] || 'master'
-    const release_path = release + '.tar.gz';
+    const release_path =  `${release}.tar.gz`;
     const compressed = _.last(_.split(release_path, '/'));
     const decompressed = _.replace('particle-' + release, '/', '-');
-    const download_url = 'https://github.com/phase2/particle/archive/' + release_path;
+    const download_url = `https://github.com/phase2/particle/archive/${release_path}`;
     const dest = options.themePath ? path.resolve(process.cwd(), options.themePath) : './';
     const themeName = 'patternlab';
     const themePathFull = path.join(dest, themeName);
 
-    this.log('Assembling your Particle theme on release "' + release + '"...');
+    this.log(`Assembling your Pattern Lab Starter/Particle theme on version ${release}...`);
 
     try {
       fs.removeSync(compressed);
@@ -82,10 +82,10 @@ module.exports = Generator.extend({
 
     // @todo replace tarball retrieval & extraction with a Node library.
     try {
-      this.log('Retrieving template from ' + download_url + '...');
+      this.log(`Retrieving template from ${download_url}...`);
       exec([
-        'curl --fail --silent -OL ' + download_url,
-        'tar -xzf ' + compressed
+        `curl --fail --silent -OL ${download_url}`,
+        `tar -xzf ${compressed}`
       ].join(' && '), {
         encoding: 'utf8'
       });
@@ -100,7 +100,7 @@ module.exports = Generator.extend({
       try {
         fs.mkdirpSync(dest);
       } catch(error) {
-        this.log.error('Could not create the theme path: ' + error);
+        this.log.error(`Could not create the theme path: ${error}`);
         process.exit(2);
       }
     }
@@ -109,7 +109,7 @@ module.exports = Generator.extend({
       fs.renameSync(decompressed, themePathFull)
     } catch(error) {
       console.error(error);
-      this.log.error('Could not move theme into position: ' + error);
+      this.log.error(`Could not move theme into position: ${error}`);
       process.exit(2);
     }
   },

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "chalk": "^1.1.3",
+    "fs-extra": "^4.0.2",
     "lodash": "^4.17.4",
     "yeoman-generator": "^1.1.0",
     "yosay": "^1.2.1"


### PR DESCRIPTION
A few little changes, but the heart of this is to minimize the amount of exec'd commands. I wanted to use a library such as tarball-extract (alluded to in #25) but that project depends on an ancient release of a node wget library that can't follow redirects, which immediately slams against Github's infrastructure.

This change adds a new --release flag to facilitate testing/using the generator with code other than master on the particle project.

There is also some general robustness improvements, such as failing earlier if curl asplodes, removing extra file copy and delete operations, and supporting the generator recursively creating the base directory of the theme in case someone specified a deeply nested location.

With this change I suppose I'll follow up with a v3.1.0 release.